### PR TITLE
Implementing delete user operation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes # (issue)
-
 ## Type of change
 
 Please delete options that are not relevant.

--- a/src/Personal.Control.Repositories/Models/User.cs
+++ b/src/Personal.Control.Repositories/Models/User.cs
@@ -20,11 +20,23 @@ namespace Personal.Control.Repositories.Models
         /// </summary>
         public string Password { get; set; }
 
+        private User(string id)
+        {
+            Id = id;
+            Email = null!;
+            Password = null!;
+        }
+
         public User(string id, string email, string password)
         {
             Id = id;
             Email = email;
             Password = password;
+        }
+
+        internal static User CreateDeletableUser(string id)
+        {
+            return new User(id);
         }
     }
 }

--- a/src/Personal.Control.Repositories/Repositories/Interfaces/IUserRepository.cs
+++ b/src/Personal.Control.Repositories/Repositories/Interfaces/IUserRepository.cs
@@ -26,6 +26,13 @@ namespace Personal.Control.Repositories.Repositories.Interfaces
         /// </summary>
         /// <param name="user">User filled with desired data to be updated. Null/empty fields won't be considered.</param>
         /// <returns></returns>
-        Task<User> UpdateAsync(User user);
+        public Task<User> UpdateAsync(User user);
+
+        /// <summary>
+        /// Deletes user data from database
+        /// </summary>
+        /// <param name="id">Id of the user to be deleted</param>
+        /// <returns></returns>
+        public Task DeleteAsync(string id);
     }
 }

--- a/src/Personal.Control.Repositories/Repositories/UserRepository.cs
+++ b/src/Personal.Control.Repositories/Repositories/UserRepository.cs
@@ -49,5 +49,21 @@ namespace Personal.Control.Repositories.Repositories
             await context.SaveChangesAsync();
             return savedUser;
         }
+
+        public async Task DeleteAsync(string id)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            var user = User.CreateDeletableUser(id);
+            var deleteUser = context.Users.Attach(user);
+            deleteUser.State = EntityState.Deleted;
+            try
+            {
+                await context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                deleteUser.State = EntityState.Detached;
+            }
+        }
     }
 }

--- a/src/Personal.Control.Services/Services/Interfaces/IUserService.cs
+++ b/src/Personal.Control.Services/Services/Interfaces/IUserService.cs
@@ -26,5 +26,12 @@ namespace Personal.Control.Services.Services.Interfaces
         /// <param name="user">User entity with fields to be updated. Fields null or empty won't be updated</param>
         /// <returns>A task with the updated user</returns>
         public Task<User> UpdateAsync(User user);
+
+        /// <summary>
+        /// Delete user data. If no user is already deleted, it will return the same response.
+        /// </summary>
+        /// <param name="id">Id of the user to be deleted</param>
+        /// <returns></returns>
+        public Task DeleteAsync(string id);
     }
 }

--- a/src/Personal.Control.Services/Services/UserService.cs
+++ b/src/Personal.Control.Services/Services/UserService.cs
@@ -1,8 +1,6 @@
 ﻿using AutoMapper;
 using Personal.Control.Repositories.Repositories.Interfaces;
 using Personal.Control.Services.Services.Interfaces;
-using Personal.Control.Utils.Exceptions;
-using Personal.Control.Utils.Messages;
 using User = Personal.Control.Services.Models.User;
 
 namespace Personal.Control.Services.Services
@@ -40,6 +38,11 @@ namespace Personal.Control.Services.Services
 
             var serviceUser = _mapper.Map<User>(updatedUserDb);
             return serviceUser;
+        }
+
+        public async Task DeleteAsync(string id)
+        {
+            await _userRepository.DeleteAsync(id);
         }
     }
 }

--- a/src/Personal.Control/Controllers/UsersController.cs
+++ b/src/Personal.Control/Controllers/UsersController.cs
@@ -80,12 +80,12 @@ namespace Personal.Control.Controllers
         /// </summary>
         /// <param name="id">User id</param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
         [HttpDelete]
         [Route("{id}")]
-        public IActionResult Delete(string id)
+        public async Task<IActionResult> Delete(string id)
         {
-            throw new NotImplementedException();
+            await _userService.DeleteAsync(id);
+            return NoContent();
         }
 
         /// <summary>

--- a/test/Personal.Control.Repositories.Tests/Repositories/UserRepositoryTests.cs
+++ b/test/Personal.Control.Repositories.Tests/Repositories/UserRepositoryTests.cs
@@ -91,5 +91,23 @@ namespace Personal.Control.Repositories.Tests.Repositories
 
             Assert.Equal(user?.Email, returnedUser.Email);
         }
+
+        [Fact]
+        public async Task DeleteAsync_WhenIdExists_ShouldDeleteIt()
+        {
+            var savedUser = _fixture.Create<User>();
+
+            await _userRepository.SaveAsync(savedUser);
+            await _userRepository.DeleteAsync(savedUser.Id);
+
+            await Assert.ThrowsAsync<EntityNotFoundException>(() => _userRepository.GetAsync(savedUser.Id));
+        }
+
+        [Fact]
+        public async Task DeleteAsync_WhenIdDoesntExist_ShouldThrowNoException()
+        {
+            var id = _fixture.Create<string>();
+            await _userRepository.DeleteAsync(id);
+        }
     }
 }

--- a/test/Personal.Control.Repositories.Tests/Repositories/UserRepositoryTests.cs
+++ b/test/Personal.Control.Repositories.Tests/Repositories/UserRepositoryTests.cs
@@ -107,7 +107,10 @@ namespace Personal.Control.Repositories.Tests.Repositories
         public async Task DeleteAsync_WhenIdDoesntExist_ShouldThrowNoException()
         {
             var id = _fixture.Create<string>();
+            var getTask = _userRepository.GetAsync(id);
             await _userRepository.DeleteAsync(id);
+
+            await Assert.ThrowsAsync<EntityNotFoundException>(() => getTask);
         }
     }
 }

--- a/test/Personal.Control.Services.Tests/Services/UserServiceTests.cs
+++ b/test/Personal.Control.Services.Tests/Services/UserServiceTests.cs
@@ -56,5 +56,13 @@ namespace Personal.Control.Services.Tests.Services
             await _userService.UpdateAsync(user);
             _userRepository.Verify(ur => ur.UpdateAsync(It.IsAny<Repositories.Models.User>()), Times.Once);
         }
+
+        [Fact]
+        public async Task DeleteAsync_WhenCalled_ShouldDeleteOnDatabase()
+        {
+            var id = _fixture.Create<string>();
+            await _userService.DeleteAsync(id);
+            _userRepository.Verify(ur => ur.DeleteAsync(id), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR just implements the delete operation to complete the CRUD of Users.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Run the project locally and using swagger do the following:
- Create an user using the POST endpoint
- Retrieve it with GET endpoint
- Delete it with the endpoint implemented by this PR
- Call the GET endpoint again and get a 404 status code.

# Screenshots and/or evidences of the tests
![image](https://github.com/matcastro/Controle-Pessoal/assets/12246072/6b2b37de-d3bd-438d-ac57-dc560be3f0fb)
